### PR TITLE
Debugging commands and oneAPI vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -5,5 +5,6 @@
         "eamodio.gitlens",
         "tamasfe.even-better-toml",
         "fortran-lang.linter-gfortran",
+        "intel-corporation.oneapi-environment-configurator"
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,81 @@
+{  "version": "0.2.0",
+  "configurations": [
+    { "name": "(gdb) Launch main program",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/vscode/bin/${workspaceFolderBasename}",
+      // Optional arguments here:
+      "args": [],
+      "stopAtEntry": true,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        },
+        {
+          "description": "Set Disassembly Flavor to Intel",
+          "text": "-gdb-set disassembly-flavor intel",
+          "ignoreFailures": true
+        }
+      ],
+      "preLaunchTask": "fpm: install"
+    },
+    {
+      // Launch the open program in the app directory
+      "name": "(gdb) Launch open program",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/vscode/bin/${fileBasenameNoExtension}",
+      // Optional arguments here:
+      "args": [],
+      "stopAtEntry": true,
+      "cwd": "${workspaceFolder}",
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true,
+        },
+        {
+          "description": "Set Disassembly Flavor to Intel",
+          "text": "-gdb-set disassembly-flavor intel",
+          "ignoreFailures": true
+        }
+      ],
+      "preLaunchTask": "fpm: install"
+    },
+    {
+      // Launch the open test program
+      "name": "(gdb) Launch this Test",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/vscode/test/${fileBasenameNoExtension}",
+      "args": [],
+      "stopAtEntry": true,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        },
+        {
+          "description": "Set Disassembly Flavor to Intel",
+          "text": "-gdb-set disassembly-flavor intel",
+          "ignoreFailures": true
+        }
+      ],
+      "preLaunchTask": "fpm: test Single File"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,91 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Set Environment",
+      "type":"shell",
+      "command": "export FPM_FC=gfortran",
+    },
+    { "label": "fpm: install",
+      "type": "shell",
+      "command": "fpm",
+      "args": [
+        "install",
+        "--compiler", "gfortran",
+        "--c-compiler", "gcc",
+        "--profile",
+        "debug",
+        "--flag", "-Og",
+        "--prefix",
+        "${workspaceRoot}/build/vscode",
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      // Enable if using the intel OneAPI compiler
+      // "dependsOn": ["Setup OneAPI"]
+    },
+    { "label": "fpm: install example",
+      "type": "shell",
+      "command": "fpm",
+      "args": [
+        "run",
+        "--profile",
+        "debug",
+        "--example",
+        "demo",
+        "--runner",
+        "'install -b -m 0711 -p -t ./build/'"
+      ],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    { "label": "fpm: test Single File",
+      "type": "shell",
+      "command": "fpm",
+      "args": [
+        "test",
+        "--target",
+        "${fileBasenameNoExtension}",
+        "--profile",
+        "debug",
+        "--runner",
+        "cp",
+        "--",
+        "${workspaceFolder}/build/vscode/test/"
+      ],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "dependsOn": ["Copy Directory Structure"],
+      "dependsOrder": "sequence"
+    },
+    { "label": "Copy Directory Structure",
+      "type": "shell",
+      "options": { "cwd": "${workspaceFolder}/test" },
+      "linux": {
+        "command": "find",
+        "args": [
+          ".",
+          "-type",
+          "d",
+          "-exec",
+          "mkdir",
+          "-p",
+          "--",
+          "${workspaceRoot}/build/vscode/test/{}",
+          "\\;"
+        ]
+      }
+    },
+    { "label": "Setup OneAPI",
+      "command": "${command:intel-corporation.oneapi-environment-configurator.initializeEnvironment}"
+    },
+  ]
+}


### PR DESCRIPTION
I've added launch options to debug programs and tests, and also the intel oneAPI as a recommended extension.

Note: to properly debug the `main` program, the folder of the project must have the same name as it is described in the `fpm.toml` file